### PR TITLE
Route all QUID-6 outcomes to surgeon, show diagnosis code

### DIFF
--- a/src/pages/scheduling/index.tsx
+++ b/src/pages/scheduling/index.tsx
@@ -10,7 +10,7 @@ import {
   PathStep
 } from './util/workflow';
 import Button from '../../components/button';
-import Quid6Questionnaire, { DiagnosisType, Quid6Result } from './components/Quid6Questionnaire';
+import Quid6Questionnaire, { Quid6Result } from './components/Quid6Questionnaire';
 import { AuditKeyDisplay } from './components/AuditKeyDisplay';
 import { useAuditStorage } from '../../hooks/useAuditStorage';
 
@@ -64,17 +64,8 @@ const Scheduling: React.FC = () => {
     
     // Determine the next node based on QUID-6 results
     let nextNodeId: string;
-    switch (result.diagnosis) {
-      case 'Stress Incontinence':
-      case 'Stress-Predominant Mixed':
-        nextNodeId = 'scheduleWithSurgeon';
-        break;
-      case 'Urge Incontinence':
-      case 'Urge-Predominant Mixed':
-      default:
-        nextNodeId = 'scheduleWithAPP';
-        break;
-    }
+    // All QUID-6 outcomes route to surgeon
+    nextNodeId = 'scheduleWithSurgeon';
     
     // Add QUID-6 result information to the path
     const updatedPath = [...path];
@@ -247,8 +238,22 @@ const Scheduling: React.FC = () => {
               {currentNode.type === 'result' && currentNode.result && (
                 <div className="mt-4">
                   {renderProviderInfo(currentNode.result)}
-                  {auditKey && auditKey !== 'FAILED' && <AuditKeyDisplay auditKey={auditKey} />}
-                  {auditKey === 'FAILED' && (
+                  {quid6Result && (
+                    <div className="mt-4 p-3 bg-gray-100 rounded-md text-center">
+                      <span className="text-sm text-gray-600">Diagnosis: </span>
+                      <span className="text-lg font-bold font-mono">
+                        {({
+                          'Stress Incontinence': 'SUI',
+                          'Urge Incontinence': 'UUI',
+                          'Stress-Predominant Mixed': 'SPMUI',
+                          'Urge-Predominant Mixed': 'UPMUI',
+                          'Inconclusive': 'INCON',
+                        } as Record<string, string>)[quid6Result.diagnosis]}
+                      </span>
+                    </div>
+                  )}
+                  {!quid6Result && auditKey && auditKey !== 'FAILED' && <AuditKeyDisplay auditKey={auditKey} />}
+                  {!quid6Result && auditKey === 'FAILED' && (
                     <div className="mt-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
                       <h3 className="text-sm font-medium text-yellow-900 mb-2">
                         Audit Trail Unavailable


### PR DESCRIPTION
## Summary
- All QUID-6 outcomes now route to Surgeon regardless of stress/urge diagnosis
- Replaced audit key display with diagnosis abbreviation (SUI, UUI, SPMUI, UPMUI, INCON) on QUID-6 result screens
- Non-QUID-6 paths still show the audit key as before

## Test plan
- [ ] Complete QUID-6 with stress-dominant answers → verify Surgeon result + SUI code
- [ ] Complete QUID-6 with urge-dominant answers → verify Surgeon result (not APP) + UUI code
- [ ] Complete QUID-6 with mixed answers → verify correct SPMUI/UPMUI code
- [ ] Complete QUID-6 with low scores → verify INCON code
- [ ] Non-QUID-6 path (e.g., Prolapse) → verify audit key still displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)